### PR TITLE
fix Content-Length=0

### DIFF
--- a/src/htstream.app.src
+++ b/src/htstream.app.src
@@ -1,7 +1,7 @@
 {application, htstream,
    [
       {description, "http stream parser"},
-      {vsn,         "1.0.2"},
+      {vsn,         "1.0.3"},
       {modules,     []},
       {registered,  []},
       {applications,[

--- a/src/htstream.erl
+++ b/src/htstream.erl
@@ -854,7 +854,12 @@ is_payload_entity(#http{headers = Head} = State) ->
       _ ->
          case lists:keyfind(<<"Content-Length">>, 1, Head) of
             {_, Len} ->
-               {ok, State#http{is = eoh, length = htstream_codec:i(Len)}};
+               case htstream_codec:i(Len) of
+                  Val when Val > 0 ->
+                     {ok, State#http{is = eoh, length = Val}};
+                  _ ->
+                     false
+               end;
             _ ->
                false
          end


### PR DESCRIPTION
State machine stall with request that containes explicit length = 0
```
> OPTIONS / HTTP/1.1
> Host: localhost:8080
> User-Agent: curl/7.54.0
> Accept: */*
> Origin: null
> Connection: keep-alive
> Content-Length: 0
```